### PR TITLE
Expose screen grid

### DIFF
--- a/src/screen.rs
+++ b/src/screen.rs
@@ -683,7 +683,7 @@ impl Screen {
         self.attrs.inverse()
     }
 
-    pub(crate) fn grid(&self) -> &crate::grid::Grid {
+    pub fn grid(&self) -> &crate::grid::Grid {
         if self.mode(MODE_ALTERNATE_SCREEN) {
             &self.alternate_grid
         } else {


### PR DESCRIPTION
Okay, so basically the functionality I'm looking for is the capability to Iterate through the Cells of the Rows (and get actual `Cell` objects not just the raw bytes). It seems nominal to do if the grid is actually exposed (Through then calling `grid.visible_rows()` or `grid.drawing_rows()`). Exposing the grid also helps with a whole host of other specialised functionality which I'd imagine will be useful for advanced users of this library. Anyways an alternative way to get the functionality is to just expose those two functions of the grid, however I simultaneously think it makes more sense to just expose the (non-mutable) grid, I can't really think of a good reason to not do so besides fewer breaking changes which I don't think really matters especially for a repo with so few users at this point (it's not like there are going to be very many patches anytime soon)

Let me know your thoughts